### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,24 +6,24 @@
 # Datatypes (KEYWORD1)
 ###################################
 
-Synth   KEYWORD1
+Synth	KEYWORD1
 
 ###################################
 # Methods and Functions (KEYWORD2)
 ###################################
 
-syn KEYWORD2
-tone    KEYWORD2
+syn	KEYWORD2
+tone	KEYWORD2
 tone_type	KEYWORD2
-tone_seeded KEYWORD2
-tone_custom KEYWORD2
-stop    KEYWORD2
+tone_seeded	KEYWORD2
+tone_custom	KEYWORD2
+stop	KEYWORD2
 
 ###################################
 # Constants (LITERAL1)
 ###################################
 
-SQUARE_WAVE LITERAL1
-SAWTOOTH_WAVE   LITERAL1
-TRIANGLE_WAVE   LITERAL1
-SINE_WAVE   LITERAL1
+SQUARE_WAVE	LITERAL1
+SAWTOOTH_WAVE	LITERAL1
+TRIANGLE_WAVE	LITERAL1
+SINE_WAVE	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords